### PR TITLE
adds m1 support

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -35,6 +35,7 @@ platform() {
 
   case "$(uname -m)" in
     x86_64 | x86-64 | x64 | amd64) architecture="amd64" ;;
+    arm64) architecture="arm64" ;;
     *) fail "Unsupported architecture" ;;
   esac
 


### PR DESCRIPTION
Before:
```bash
* Downloading please release 16.23.1...
curl: (3) bad range in URL position 87:
https://github.com/thought-machine/please/releases/download/v16.23.1/please_16.23.1_Fail: Unsupported architecture.tar.xz
                                                                                      ^
Fail: Could not download https://github.com/thought-machine/please/releases/download/v16.23.1/please_16.23.1_Fail: Unsupported architecture.tar.xz
Fail: An error ocurred while installing please 16.23.1.
```
After:
```
* Downloading please release 16.23.1...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 16.9M  100 16.9M    0     0  20.9M      0 --:--:-- --:--:-- --:--:-- 51.5M
please 16.23.1 installation was successful!
```
(repointing of this PR https://github.com/asdf-community/asdf-please/pull/3)