### PR TITLE
uses build sort -V to sort semver

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -16,8 +16,7 @@ if test -n "$GITHUB_API_TOKEN"; then
 fi
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+  sort -V
 }
 
 list_github_tags() {


### PR DESCRIPTION
before 
```
16.25.1
16.26.0
16.26.1
2.0.0
2.1.2
3.0.0
3.0.1
3.0.2
....
9.3.0
9.4.0
9.5.0
```
After:
```
...
15.17.0
15.17.1
16.0.0
16.0.0-prerelease.1
16.0.0-prerelease.2
16.0.0-prerelease.3
16.0.0-prerelease.4
...
16.20.0-beta.10
16.20.0-beta.11
16.20.0-beta.12
16.20.0-beta.13
16.20.0-beta.14
16.20.0-beta.15
16.20.0-beta.16
16.20.0-beta.17
16.20.1
16.20.2
16.20.3
16.20.4
16.21.0
16.21.1
16.21.2
16.21.3
16.22.0
16.22.1
16.23.0
16.23.1
16.24.0
16.25.0
16.25.1
16.26.0
16.26.1
```